### PR TITLE
refactor: different way of fetching the avo version

### DIFF
--- a/bin/bud
+++ b/bin/bud
@@ -77,8 +77,12 @@ module Buddy
 
         option :gem, aliases: ["-g"], required: false, desc: "The gem where you want to run the command on"
 
-        def call(gem: nil, **)
+        def call(gem: nil, forced_avo_version: nil, **)
           FileUtils.mkdir_p "pkg"
+
+          avo_version = forced_avo_version || avo_gem_version
+
+          say "avo version: #{avo_version}"
 
           remove_previous_gem
 
@@ -97,7 +101,7 @@ module Buddy
 
           # Build the build image
           say "Building Docker image"
-          run("docker build -t #{name} -f ./../support/docker/#{dockerfile} #{build_path} --progress #{DOCKER_PROGRESS} --build-arg NAME=#{name} --build-arg GEMSPEC_NAME=#{gemspec_name} --build-arg BUNDLER_TOKEN=#{bundler_token}")
+          run("docker build -t #{name} -f ./../support/docker/#{dockerfile} #{build_path} --progress #{DOCKER_PROGRESS} --build-arg NAME=#{name} --build-arg GEMSPEC_NAME=#{gemspec_name} --build-arg BUNDLER_TOKEN=#{bundler_token} --build-arg AVO_VERSION=#{avo_version}")
           say "Docker image built"
 
           src = "/#{name}/pkg/#{gemspec_name}-#{version}.gem"
@@ -153,7 +157,7 @@ module Buddy
         option :skip_bump, type: :boolean, aliases: ["-sb"], required: false, desc: "Skip bumping the version."
         argument :level, desc: "major|minor|patch|pre"
 
-        def call(gem: nil, skip_bump: false, level: "minor", **)
+        def call(gem: nil, skip_bump: false, level: "patch", **)
           # 1. Bump gem version
           if skip_bump
             # Run bundle to increment the version number in Gemfile.lock

--- a/bin/support.rb
+++ b/bin/support.rb
@@ -34,6 +34,12 @@ def version
   @version ||= gemspec.version.to_s
 end
 
+# fetch the Avo version from the avo gem
+def avo_gem_version
+  require_relative "../../avo/lib/avo/version"
+  @avo_version ||= Avo::VERSION
+end
+
 def gemspec_name
   gemspec.name
 end

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,4 +1,2 @@
 .git/
 node_modules/
-spec/
-tmp/

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,2 +1,4 @@
-node_modules
-spec
+.git/
+node_modules/
+spec/
+tmp/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM avo_gems
 ARG NAME
 ARG GEMSPEC_NAME
 ARG BUNDLER_TOKEN
+ARG AVO_VERSION
 
 WORKDIR /${NAME}/
 
@@ -12,6 +13,7 @@ RUN mkdir /${NAME}/lib/avo
 RUN mkdir /${NAME}/lib/avo/${NAME}
 
 ENV BUNDLE_WITHOUT=development:test
+ENV AVO_VERSION=${AVO_VERSION}
 
 # Cache the bundle install command with a fake version
 COPY ./tmp/Gemfile_v1.lock /${NAME}/Gemfile.lock


### PR DESCRIPTION
We can pass the avo version this way and maybe we can improve the build time and processing using this trick.

And in each `.gemspec` file we can find it like this

```ruby
if ENV["AVO_VERSION"]
  Avo::VERSION = ENV["AVO_VERSION"]
else
  require_relative "../avo/lib/avo/version" unless defined?(Avo::VERSION)
end
```