### PR TITLE
Improve testing CI workflows

### DIFF
--- a/.github/workflows/feature-tests.yml
+++ b/.github/workflows/feature-tests.yml
@@ -40,6 +40,7 @@ env:
 jobs:
   feature_specs:
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - '3.3'
@@ -47,6 +48,7 @@ jobs:
           - '8.0'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     env:
       RAILS_VERSION: ${{matrix.rails}}
@@ -54,7 +56,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:16
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
@@ -70,24 +72,26 @@ jobs:
     - name: Add AVO_GEM_TOKEN
       run: bundle config set --global https://packager.dev/avo-hq/ ${{secrets.AVO_GEM_TOKEN}}
 
-    - uses: actions/cache@v4
+    - name: Restore gem cache
+      uses: actions/cache/restore@v5
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-test-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-test-gems-${{ hashFiles('**/Gemfile.lock') }}
+          ${{ runner.os }}-test-gems-
 
     - name: Get yarn cache directory path
       id: test-yarn-cache-dir-path
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@v4
+    - name: Restore yarn cache
+      uses: actions/cache/restore@v5
       id: test-yarn-cache
       with:
         path: ${{ steps.test-yarn-cache-dir-path.outputs.dir }}
         key: ${{ runner.os }}-test-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
-          ${{ runner.os }}-test-yarn-${{ hashFiles('**/yarn.lock') }}
+          ${{ runner.os }}-test-yarn-
 
     - name: Clone Avo repositories
       shell: bash
@@ -151,6 +155,20 @@ jobs:
     - name: Run tests
       id: run_tests
       run: bundle exec rspec spec/features
+
+    - name: Save gem cache
+      if: always()
+      uses: actions/cache/save@v5
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-test-gems-${{ hashFiles('**/Gemfile.lock') }}
+
+    - name: Save yarn cache
+      if: always()
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ steps.test-yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-test-yarn-${{ hashFiles('**/yarn.lock') }}
 
     - uses: actions/upload-artifact@v4
       if: always() && steps.run_tests.outcome == 'failure'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,8 @@ jobs:
           ruby-version: 3.3.0
 
       - name: standardrb
-        uses: avo-hq/action-standardrb@master
+        # Pinned to a SHA (master @ 2026-06-17) rather than a moving branch for reproducibility.
+        uses: avo-hq/action-standardrb@5fd05db1ad01480dda7e3135b0cf352c51e792f1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review # Default is github-pr-check
@@ -40,7 +41,7 @@ jobs:
           ruby-version: 3.3.0
 
       - name: Install erb_lint
-        run: gem install erb_lint
+        run: gem install erb_lint -v 0.9.0
 
       # The action requires a config file. Provide erb_lint's default linters
       # unless the repo ships its own .erb_lint.yml, so consuming gems need no
@@ -67,24 +68,18 @@ jobs:
         id: check_file
         run: |
           if [ -f .eslintrc.json ]; then
-            echo "file_exists=true" >> $GITHUB_ENV
+            echo "file_exists=true" >> $GITHUB_OUTPUT
           else
-            echo "file_exists=false" >> $GITHUB_ENV
+            echo "file_exists=false" >> $GITHUB_OUTPUT
           fi
 
   eslint:
     name: runner / eslint
     runs-on: ubuntu-latest
-    if: github.env.file_exists == 'true'
+    needs: check-eslint-config
+    if: needs.check-eslint-config.outputs.file_exists == 'true'
     steps:
       - uses: actions/checkout@v4
-      - name: Check for eslint config
-        run: |
-          pwd
-          if [ ! -f .eslintrc.json ]; then
-            echo "File not found!"
-            exit 0
-          fi
       - run: yarn add global eslint@6.8.0 eslint-plugin-sort-imports-es6-autofix@^0.5.0 eslint-config-airbnb@^18.1.0 eslint-config-airbnb-base@^14.1.0 babel-eslint@^10.1.0 eslint-plugin-import@^2.20.2
       - name: eslint
         uses: reviewdog/action-eslint@v1

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -39,6 +39,7 @@ env:
 jobs:
   system_specs:
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - "3.3"
@@ -46,6 +47,7 @@ jobs:
           - "8.0"
 
     runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     env:
       RAILS_VERSION: ${{matrix.rails}}
@@ -53,7 +55,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:16
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 


### PR DESCRIPTION
Fixes and hardening for the reusable test/lint workflows (`feature-tests.yml`, `system-tests.yml`, `lint.yml`).

## Bugs fixed

- **eslint never ran** (`lint.yml`). The config-check job wrote `file_exists` to `$GITHUB_ENV` but declared it as a step output (only populated from `$GITHUB_OUTPUT`), and the `eslint` job guarded on the invalid `github.env.file_exists` with no `needs:`. Now wired correctly via `$GITHUB_OUTPUT`, `needs: check-eslint-config`, and `needs.check-eslint-config.outputs.file_exists`. ⚠️ eslint will now actually run when a consuming repo ships `.eslintrc.json` — some repos may surface previously-hidden lint errors.
- **No-op cache restore-keys** (`feature-tests.yml`). The `restore-keys` were identical to the cache `key`, so a `Gemfile.lock`/`yarn.lock` change fell back to nothing. Now use the prefix, matching `system-tests.yml`.
- **feature-tests never saved its cache.** Switched to the `cache/restore@v5` + `cache/save@v5` split and added explicit save steps.

## Hardening

- Bump Postgres `10.8` → `16` in both test workflows (10.8 has been EOL since Nov 2022).
- Add `fail-fast: false` and `timeout-minutes` (30 feature / 40 system) so a hung browser spec can't run to the 6h default and all matrix legs report.
- Pin `avo-hq/action-standardrb` to a SHA instead of `@master`; pin `erb_lint` to `0.9.0`.

## Not included

- **bundler-cache swap** — deliberately left out. `ruby/setup-ruby`'s `bundler-cache: true` runs `bundle install` inside the setup step, but these workflows must install *after* the clone step (Gemfiles reference the cloned `../avo` siblings) and the registry-auth step. A real migration needs step reordering and can't be verified from this repo. Filed as a possible follow-up.
- Composite action for the duplicated "Clone Avo repositories" block (still duplicated across both files).
- Declaring `GH_REGISTRY_AVO_FILTERS_TOKEN` in the reusable workflow's `secrets:` block (still relies on `secrets: inherit` at call sites).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/avo-hq/codesmith/support/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784318853&installation_id=139851646&pr_number=13&repository=avo-hq%2Fsupport&return_to=https%3A%2F%2Fgithub.com%2Favo-hq%2Fsupport%2Fpull%2F13&signature=9aa41f1213c8624013063b2134e87ce8cb41601d343841c3d137b30d320902ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->