### PR TITLE
Fix postgres:16 CI service: allow passwordless connections

### DIFF
--- a/.github/workflows/feature-tests.yml
+++ b/.github/workflows/feature-tests.yml
@@ -57,6 +57,8 @@ jobs:
     services:
       postgres:
         image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -56,6 +56,8 @@ jobs:
     services:
       postgres:
         image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 


### PR DESCRIPTION
## Summary

CI's database stopped starting after the June 17 workflow change bumped the postgres service from `postgres:10.8` to `postgres:16`. `postgres:16` refuses to initialize unless `POSTGRES_PASSWORD` or `POSTGRES_HOST_AUTH_METHOD` is set, so every repo that consumes these reusable workflows now fails at container startup:

```
Error: Database is uninitialized and superuser password is not specified.
##[error]Failed to initialize container postgres:16
##[error]One or more containers failed to start.
```

The `10.8` image accepted passwordless/trust connections, which is exactly what the job environment expects — it sets `PGUSER=postgres` with no `PGPASSWORD`. This restores that behavior by setting `POSTGRES_HOST_AUTH_METHOD: trust` on the service container, in both `system-tests.yml` and `feature-tests.yml`.

## Impact

Affects every gem using these reusable workflows (avo-pro, avo-advanced, avo-notifications, etc.). The last green runs were June 13 (pre-bump); all System/Feature Tests since June 17 fail at postgres init in ~20s. This unblocks them.

## Verification

Confirmed locally that the consuming dummy app boots and `spec/system` passes against a passwordless postgres with `PGUSER=postgres` and no `PGPASSWORD`, matching the job env.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/avo-hq/codesmith/support/pr/14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784732722&installation_id=139851646&pr_number=14&repository=avo-hq%2Fsupport&return_to=https%3A%2F%2Fgithub.com%2Favo-hq%2Fsupport%2Fpull%2F14&signature=3faa38ee9b16d24cc6689569b19fb5e38b96e537159ece22a75cd0d9ec444d17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->