### PR TITLE
Fix postgres:16 service startup in CI workflows

### DIFF
--- a/.github/workflows/feature-tests.yml
+++ b/.github/workflows/feature-tests.yml
@@ -57,6 +57,8 @@ jobs:
     services:
       postgres:
         image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -56,6 +56,8 @@ jobs:
     services:
       postgres:
         image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 


### PR DESCRIPTION
## Problem

The reusable `system-tests.yml` and `feature-tests.yml` workflows start a `postgres:16` service container with no auth env. Modern postgres images refuse to initialize without one, so the container never starts and CI fails before any test runs:

```
Error: Database is uninitialized and superuser password is not specified.
You must specify POSTGRES_PASSWORD to a non-empty value for the superuser.
...
You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all connections without a password.
```

This affects every gem that calls these reusable workflows (surfaced on avo-notifications PR #1).

## Fix

Add `POSTGRES_HOST_AUTH_METHOD: trust` to the postgres service in both workflows — the standard GitHub Actions postgres setup. The DB is ephemeral and network-isolated to the runner, so trust auth is safe in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/avo-hq/codesmith/support/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784792636&installation_id=139851646&pr_number=15&repository=avo-hq%2Fsupport&return_to=https%3A%2F%2Fgithub.com%2Favo-hq%2Fsupport%2Fpull%2F15&signature=edae23fd98c8ce9f5d78a5e8ae016b235d2ee379dea1dd183622cce06cc2482f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->