### PR TITLE
Fix postgres service container init in CI

### DIFF
--- a/.github/workflows/feature-tests.yml
+++ b/.github/workflows/feature-tests.yml
@@ -57,6 +57,8 @@ jobs:
     services:
       postgres:
         image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -56,6 +56,8 @@ jobs:
     services:
       postgres:
         image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 


### PR DESCRIPTION
## Summary

CI's `postgres:16` service container fails to start with:

```
Error: Database is uninitialized and superuser password is not specified.
You must specify POSTGRES_PASSWORD to a non-empty value for the superuser.
Error: Failed to initialize container postgres:16
```

Recent `postgres` images refuse to initialize without either a superuser password or an explicit auth method. Our workflows connect as the passwordless `postgres` user (`PGUSER: postgres`, no `PGPASSWORD`), so this adds `POSTGRES_HOST_AUTH_METHOD: trust` to the service, which keeps passwordless connections working in CI.

Applied to both reusable workflows that spin up postgres:

- `.github/workflows/system-tests.yml`
- `.github/workflows/feature-tests.yml`

## Test plan

- [ ] A consuming repo's System Tests job starts the postgres service successfully and connects.
- [ ] Feature Tests job likewise initializes postgres and runs.

Made with [Cursor](https://cursor.com)